### PR TITLE
Gracefully fallback when implicit_order_column not defined

### DIFF
--- a/lib/activerecord-implicit-order/core_extensions.rb
+++ b/lib/activerecord-implicit-order/core_extensions.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         if implicit_order_column_defined && primary_key && implicit_order_column != primary_key
           order(arel_attribute(implicit_order_column).asc, arel_attribute(primary_key).asc)
         else
-          order(arel_attribute(implicit_order_column || primary_key).asc)
+          order(arel_attribute(implicit_order_column_defined || primary_key).asc)
         end
       else
         self

--- a/lib/activerecord-implicit-order/core_extensions.rb
+++ b/lib/activerecord-implicit-order/core_extensions.rb
@@ -1,8 +1,10 @@
 module ActiveRecord
   module FinderMethods
     def ordered_relation
-      if order_values.empty? && (implicit_order_column || primary_key)
-        if implicit_order_column && primary_key && implicit_order_column != primary_key
+      implicit_order_column_defined = respond_to?(:implicit_order_column) && implicit_order_column
+
+      if order_values.empty? && (implicit_order_column_defined || primary_key)
+        if implicit_order_column_defined && primary_key && implicit_order_column != primary_key
           order(arel_attribute(implicit_order_column).asc, arel_attribute(primary_key).asc)
         else
           order(arel_attribute(implicit_order_column || primary_key).asc)


### PR DESCRIPTION
I know this is silly and understand if you ignore, but sometimes we are not in control of all the Models used in our system. 

Particularly stuff like this:

![image](https://user-images.githubusercontent.com/1264305/76588396-49ebad00-64bd-11ea-9a91-cafe6b676520.png)

Using `extend` I think is the root problem, if there are models in your system ignoring your abstract class, it's still calling the method but it's missing. Obviously a hack, but works.